### PR TITLE
Use DNS round robin for database service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - 'redis:/var/lib/redis/data'
   db:
     image: 'mysql:5.7'
+    deploy:
+      endpoint_mode: dnsrr
     environment:
       MYSQL_DATABASE: ${DATABASE_NAME}
       MYSQL_PASSWORD_FILE: /run/secrets/bulwark_database_password


### PR DESCRIPTION
This works around an issue where Swarm will terminate idle connections after 900 seconds. Our automated ingest jobs regularly exceed this timeout and we're currently unable to adjust the keepalive settings in the containers.