### PR TITLE
Create Docker secret for system SSH key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,6 @@ just_jetty.sh
 # Ignore featured
 /public/featured
 
-#Ignore docker
-/docker
-
 # Other stuff
 *.rdb
 /.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ secrets:
   bulwark_secrets_config:
     external: true
     name: colenda_bulwark_secrets_config
+  bulwark_ssh_host_ecdsa_key:
+    external: true
+    name: colenda_bulwark_ssh_host_ecdsa_key
 
 services:
   redis:
@@ -131,6 +134,9 @@ services:
         target: /home/app/webapp/config/database.yml
       - source: bulwark_secrets_config
         target: /home/app/webapp/config/secrets.yml
+      - source: bulwark_ssh_host_ecdsa_key
+        target: /etc/ssh/ssh_host_ecdsa_key
+        mode: 0400
     volumes:
       - '${LOCAL_DATA}:${REMOTE_DATA}'
       - '${OPENN_HARVESTING_ENDPOINT_LOCAL}:${OPENN_HARVESTING_ENDPOINT_REMOTE}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,19 +2,24 @@ version: '3.7'
 
 configs:
   authorized_keys:
-    file: 'authorized_keys'
+    file: authorized_keys
 
 secrets:
   bulwark_database_password:
     external: true
+    name: colenda_bulwark_database_password
   bulwark_database_root_password:
     external: true
+    name: colenda_bulwark_database_root_password
   bulwark_database_config:
     external: true
+    name: colenda_bulwark_database_config
   bulwark_fedora_config:
     external: true
+    name: colenda_bulwark_fedora_config
   bulwark_secrets_config:
     external: true
+    name: colenda_bulwark_secrets_config
 
 services:
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,6 @@ secrets:
   bulwark_database_config:
     external: true
     name: colenda_bulwark_database_config
-  bulwark_fedora_config:
-    external: true
-    name: colenda_bulwark_fedora_config
   bulwark_secrets_config:
     external: true
     name: colenda_bulwark_secrets_config

--- a/docker/ssh_service.sh
+++ b/docker/ssh_service.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
 # Start the SSH service on container startup
-
-ssh-keygen -A
-
 service ssh start


### PR DESCRIPTION
We can prevent Guardian's `known_hosts` checks from failing by providing all Bulwark containers with the same system SSH key. It's handled as a secret and mounted directly into the `/etc/ssh` directory. 🔐 This was previously being generated on container start by the `ssh_service.sh` script which had previously been committed to Git but was added to `.gitignore` at some point (probably to ignore `.env` files).

I'm only providing an ECDSA encryption key because that's all we're using in our `known_hosts` file for Guardian at this time.

I've also changed some of the secret labeling and removed an unused secret to bring this Compose file up to speed with more recent conventions we've been using for Swarm configuration.

Once we get this deployed I'll update the Guardian `known_hosts` entries, hopefully for the last time! 🤞 