### PR TITLE
Hotfix/colenda 44 repo data fixes

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -45,9 +45,9 @@ class Repo < ActiveRecord::Base
   end
 
   def set_defaults
-    self[:unique_identifier].strip!
     self[:owner] = User.current
     self[:unique_identifier] = mint_ezid unless self[:unique_identifier].present?
+    self[:unique_identifier].strip!
     self[:derivatives_subdirectory] = "#{Utils.config[:object_derivatives_path]}"
     self[:admin_subdirectory] = "#{Utils.config[:object_admin_path]}"
     self[:ingested] = false

--- a/lib/utils/version_control/git_annex.rb
+++ b/lib/utils/version_control/git_annex.rb
@@ -195,7 +195,7 @@ module Utils
       end
 
       def _get_drop_calls(dir, action)
-        dir = Shellwords.escape(dir)
+        dir = Dir.exist?(Shellwords.escape(dir)) ? Shellwords.escape(dir) : dir
         if File.directory?(dir)
           Dir.chdir(dir)
           rolling_upgrade(dir)


### PR DESCRIPTION
Fixes exceptions related to unique_identifier handling and git repo path handling, specifically repos with brackets in the name.