### PR TITLE
Excluding .nfs* files

### DIFF
--- a/lib/utils/version_control/git_annex.rb
+++ b/lib/utils/version_control/git_annex.rb
@@ -183,6 +183,7 @@ module Utils
       # Almost identical to docker/init.sh
       def init_clone(dir, fsck = true)
         git = ExtendedGit.open(dir)
+        ignore_system_generated_files(dir)
         git.annex.init(version: Utils.config[:supported_vca_version])
 
         special_remote = Utils.config[:special_remote]
@@ -202,6 +203,14 @@ module Utils
       end
 
       private
+
+      # Ignore .nfs* files automatically generated and needed by the nfs store.
+      # By using `.git/info/exclude` we can exclude the files in the
+      # working directory without adding a `.gitignore` to the repo.
+      def ignore_system_generated_files(dir)
+        exclude_path = File.join(dir, '.git', 'info', 'exclude')
+        File.open(exclude_path, 'w') { |f| f.write('.nfs*') } # Ignore `.nfs* files
+      end
 
       def change_dir_working(dir)
         directory = get_directory(dir)

--- a/spec/utils/version_control/git_annex_spec.rb
+++ b/spec/utils/version_control/git_annex_spec.rb
@@ -37,5 +37,9 @@ RSpec.describe Utils::VersionControl::GitAnnex do
       expect(git.config('remote.origin.annex-ignore')).to eq 'true'
       expect(git.config('annex.largefiles')).to eq 'not (include=.repoadmin/bin/*.sh)'
     end
+
+    it 'adds to .git/info/exclude' do
+      expect(IO.read(File.join(git.repo.path, 'info', 'exclude'))).to eql '.nfs*' 
+    end
   end
 end


### PR DESCRIPTION
Ignoring `.nfs*` files that are created by the storage volume we use to clone repositories onto. 

When committing from the working directories we get messages about untracked files that prevent the code from finishing execution. 