### PR TITLE
Adding more tests for methods in Utils::VersionControl::GitAnnex and converting over some methods to use ExtendedGit.

### DIFF
--- a/app/models/metadata_builder.rb
+++ b/app/models/metadata_builder.rb
@@ -165,6 +165,7 @@ class MetadataBuilder < ActiveRecord::Base
       File.open(transformed_xml, 'w') {|f| f.puts fedora_xml }
       self.repo.version_control_agent.lock(file_path, working_path)
       self.repo.ingest(transformed_xml, working_path)
+      Dir.chdir(Rails.root.to_s) # FIXME: Eventually remove, when we don't depend on changing the directory
     end
   end
 

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -226,6 +226,7 @@ class MetadataSource < ActiveRecord::Base
     `xsltproc #{Rails.root}/lib/tasks/pqc_mets.xslt #{file_name}`
     pqc_path = "#{working_path}/#{self.metadata_builder.repo.metadata_subdirectory}/#{Utils.config['mets_xml_derivative']}"
     FileUtils.mv(Utils.config["mets_xml_derivative"], pqc_path) if Utils.config["mets_xml_derivative"].present?
+    Dir.chdir(Rails.root.to_s) # FIXME: Eventually remove, when we don't depend on changing the directory
   end
 
   def jettison_metadata(working_path, files_to_jettison)
@@ -742,6 +743,7 @@ class MetadataSource < ActiveRecord::Base
   end
 
   #TODO: Refactor to use config variables
+  # Never used.
   def _set_voyager_structural_metadata(working_path)
     mapped_values = {}
     _refresh_bibid(working_path)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -12,7 +12,7 @@ class Repo < ActiveRecord::Base
   has_many :endpoint, dependent: :destroy
   validates_associated :endpoint
 
-  around_create :set_version_control_agent_and_repo
+  around_create :set_version_control_agent_and_repo # this is essentially an after_create
 
   validates :human_readable_name, presence: true
   validates :metadata_subdirectory, presence: true
@@ -339,6 +339,7 @@ class Repo < ActiveRecord::Base
     FileExtensions.metadata_source_file_extensions
   end
 
+  # Not Called.
   def preserve_exists?
     _check_if_preserve_exists
   end
@@ -398,17 +399,17 @@ class Repo < ActiveRecord::Base
   private
 
   def _build_and_populate_directories(working_path)
-    admin_directory = "#{working_path}/#{Utils.config[:object_admin_path]}"
-    data_directory = "#{working_path}/#{Utils.config[:object_data_path]}"
-    metadata_subdirectory = "#{working_path}/#{self.metadata_subdirectory}"
-    assets_subdirectory = "#{working_path}/#{self.assets_subdirectory}"
-    derivatives_subdirectory = "#{working_path}/#{self.derivatives_subdirectory}"
+    admin_directory = File.join(working_path, Utils.config[:object_admin_path])
+    data_directory = File.join(working_path, Utils.config[:object_data_path])
+    metadata_subdirectory = File.join(working_path, self.metadata_subdirectory)
+    assets_subdirectory = File.join(working_path, self.assets_subdirectory)
+    derivatives_subdirectory = File.join(working_path, self.derivatives_subdirectory)
     readme = _generate_readme(working_path)
     _make_subdir(admin_directory)
     _make_subdir(data_directory)
-    _make_subdir(metadata_subdirectory, :keep => true)
-    _make_subdir(assets_subdirectory, :keep => true)
-    _make_subdir(derivatives_subdirectory, :keep => true)
+    _make_subdir(metadata_subdirectory, keep: true)
+    _make_subdir(assets_subdirectory, keep: true)
+    _make_subdir(derivatives_subdirectory, keep: true)
     _populate_admin_manifest("#{admin_directory}")
     init_script_directory = _add_init_scripts(admin_directory)
     [{:store => [admin_directory, derivatives_subdirectory, readme], :git => [init_script_directory, data_directory, metadata_subdirectory, assets_subdirectory]}]
@@ -470,6 +471,7 @@ class Repo < ActiveRecord::Base
     self.save!
   end
 
+  # Not called.
   def _check_if_preserve_exists
     working_path = self.version_control_agent.clone
     fname = "#{working_path}/#{self.preservation_filename}"

--- a/app/models/version_control_agent.rb
+++ b/app/models/version_control_agent.rb
@@ -39,10 +39,12 @@ class VersionControlAgent < ActiveRecord::Base
     self.worker.clone(options)
   end
 
+  # Not used.
   def reset_hard(location)
     self.worker.reset_hard(location)
   end
 
+  # Not used.
   def push_bare(location)
     self.worker.push_bare(location)
   end
@@ -51,6 +53,7 @@ class VersionControlAgent < ActiveRecord::Base
     self.worker.push(options, location)
   end
 
+  # Not used.
   def commit_bare(message, location)
     self.worker.commit_bare(message, location)
   end
@@ -71,10 +74,12 @@ class VersionControlAgent < ActiveRecord::Base
     self.worker.get(options, location)
   end
 
+  # Not used
   def sync_content(location)
     self.worker.sync(location)
   end
 
+  # Not used
   def pull(location)
     self.worker.pull(location)
   end

--- a/app/models/version_control_agent.rb
+++ b/app/models/version_control_agent.rb
@@ -39,23 +39,8 @@ class VersionControlAgent < ActiveRecord::Base
     self.worker.clone(options)
   end
 
-  # Not used.
-  def reset_hard(location)
-    self.worker.reset_hard(location)
-  end
-
-  # Not used.
-  def push_bare(location)
-    self.worker.push_bare(location)
-  end
-
   def push(options = {}, location)
     self.worker.push(options, location)
-  end
-
-  # Not used.
-  def commit_bare(message, location)
-    self.worker.commit_bare(message, location)
   end
 
   def add(options = {}, location)
@@ -72,16 +57,6 @@ class VersionControlAgent < ActiveRecord::Base
 
   def get(options = {}, location)
     self.worker.get(options, location)
-  end
-
-  # Not used
-  def sync_content(location)
-    self.worker.sync(location)
-  end
-
-  # Not used
-  def pull(location)
-    self.worker.pull(location)
   end
 
   def drop(options = {}, location)
@@ -107,9 +82,7 @@ class VersionControlAgent < ActiveRecord::Base
 
   private
 
-  def create_worker
-    @worker = "Utils::VersionControl::#{self.vc_type}".constantize.new(self.repo)
-  end
-
-
+    def create_worker
+      @worker = "Utils::VersionControl::#{self.vc_type}".constantize.new(self.repo)
+    end
 end

--- a/lib/extended_git.rb
+++ b/lib/extended_git.rb
@@ -21,6 +21,11 @@ module ExtendedGit
     Base.new(Git.open(working_dir, options))
   end
 
+  # (see Git.bare)
+  def self.bare(git_dir, options = {})
+    Base.new(Git.bare(git_dir, options))
+  end
+
   # Returns true if directory is a working directory.
   def self.is_working_directory?(directory)
     output, _status = Open3.capture2e(

--- a/lib/extended_git.rb
+++ b/lib/extended_git.rb
@@ -11,7 +11,7 @@ module ExtendedGit
     Base.new(Git.clone(repository, name, options))
   end
 
-  # (see Git.bare)
+  # (see Git.init)
   def self.init(git_dir, options = {})
     Base.new(Git.init(git_dir, options))
   end

--- a/lib/extended_git/annex.rb
+++ b/lib/extended_git/annex.rb
@@ -36,8 +36,8 @@ module ExtendedGit
       lib.fsck(options)
     end
 
-    def drop(path = nil)
-      lib.drop(path)
+    def drop(path = nil, **options)
+      lib.drop(path, options)
     end
 
     def sync(options = {})

--- a/lib/extended_git/annex.rb
+++ b/lib/extended_git/annex.rb
@@ -64,7 +64,7 @@ module ExtendedGit
       WhereIs.new(@base, path, options)
     end
 
-    def info(options = {})
+    def info
       RepositoryInfo.new(@base)
     end
 

--- a/lib/extended_git/annex.rb
+++ b/lib/extended_git/annex.rb
@@ -8,12 +8,12 @@ module ExtendedGit
       lib.version(options)
     end
 
-    def info(about = nil)
-      lib.info(about)
+    def init(name = nil, **options)
+      lib.init(name, options)
     end
 
-    def init(options = {})
-      lib.init(options)
+    def uninit
+      lib.uninit
     end
 
     def get(path)
@@ -22,6 +22,10 @@ module ExtendedGit
 
     def add(path)
       lib.add(path)
+    end
+
+    def initremote(name, options = {})
+      lib.initremote(name, options)
     end
 
     def enableremote(name, options = {})
@@ -53,11 +57,15 @@ module ExtendedGit
     end
 
     def lock(path = nil)
-      lib.unlock(path)
+      lib.lock(path)
     end
 
     def whereis(path = nil, **options)
       WhereIs.new(@base, path, options)
+    end
+
+    def info(options = {})
+      RepositoryInfo.new(@base)
     end
 
     def lib

--- a/lib/extended_git/annex.rb
+++ b/lib/extended_git/annex.rb
@@ -5,35 +5,63 @@ module ExtendedGit
     end
 
     def version(options = {})
-      @base.annex_lib.version(options)
+      lib.version(options)
     end
 
     def info(about = nil)
-      @base.annex_lib.info(about)
+      lib.info(about)
     end
 
     def init(options = {})
-      @base.annex_lib.init(options)
+      lib.init(options)
     end
 
     def get(path)
-      @base.annex_lib.get(path)
+      lib.get(path)
+    end
+
+    def add(path)
+      lib.add(path)
     end
 
     def enableremote(name, options = {})
-      @base.annex_lib.enableremote(name, options)
+      lib.enableremote(name, options)
     end
 
     def fsck(options = {})
-      @base.annex_lib.fsck(options)
+      lib.fsck(options)
     end
 
-    def drop(path)
-      @base.annex_lib.drop(path)
+    def drop(path = nil)
+      lib.drop(path)
+    end
+
+    def sync(options = {})
+      lib.sync(options)
+    end
+
+    def copy(path, options = {})
+      lib.copy(path, options)
     end
 
     def testremote(name, options = {})
-      @base.annex_lib.testremote(name, options)
+      lib.testremote(name, options)
+    end
+
+    def unlock(path = nil)
+      lib.unlock(path)
+    end
+
+    def lock(path = nil)
+      lib.unlock(path)
+    end
+
+    def whereis(path = nil, **options)
+      WhereIs.new(@base, path, options)
+    end
+
+    def lib
+      @lib ||= ExtendedGit::AnnexLib.new(@base)
     end
   end
 end

--- a/lib/extended_git/annex_lib.rb
+++ b/lib/extended_git/annex_lib.rb
@@ -145,7 +145,7 @@ module ExtendedGit
         # TODO:global config, pointing at correct working path and git dir
         global_opts = []
         global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
-        global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
+        global_opts << "--work-tree=#{@git_work_dir}" if @git_work_dir
 
         global_opts = global_opts.flatten.join(' ') # TODO: should be escaped?
 

--- a/lib/extended_git/annex_lib.rb
+++ b/lib/extended_git/annex_lib.rb
@@ -19,12 +19,16 @@ module ExtendedGit
     # accepts options:
     #   :version (with version number)
     #   :autoenable
-    def init(opts = {})
+    def init(name, opts = {})
       array_opts = []
       array_opts << "--version=#{opts[:version]}" if opts[:version]
-      array_opts << "--autoenable" if opts[:autoenable]
 
-      command('init', array_opts)
+      command("init #{name}", array_opts)
+    end
+
+    # De-initialize git-annex and clean out repository.
+    def uninit
+      command('uninit')
     end
 
     # Returns version of git-annex running and repository version information.
@@ -36,11 +40,6 @@ module ExtendedGit
       array_opts << '--raw' if opts[:raw]
 
       command('version', array_opts)
-    end
-
-    # Returns information about an item or repository
-    def info(about = nil)
-      command("info #{about}")
     end
 
     # Adds file to git-annex
@@ -58,6 +57,15 @@ module ExtendedGit
       array_opts << "directory=#{opts[:directory]}" if opts[:directory]
 
       command("enableremote #{name}", array_opts)
+    end
+
+    def initremote(name, opts = {})
+      array_opts = []
+      array_opts << "type=#{opts[:type]}"            if opts[:type]
+      array_opts << "directory=#{opts[:directory]}"  if opts[:directory]
+      array_opts << "encryption=#{opts[:encryption]}" if opts[:encryption]
+
+      command("initremote #{name}", array_opts)
     end
 
     def fsck(opts = {})
@@ -80,6 +88,7 @@ module ExtendedGit
       command("testremote #{name}", array_opts)
     end
 
+    # Returns information about where files are located.
     def whereis(path = nil, opts = {})
       array_opts = []
       array_opts << '--json'     if opts[:json]
@@ -87,6 +96,14 @@ module ExtendedGit
       array_opts << '--locked'   if opts[:locked]
 
       command("whereis #{path}", array_opts)
+    end
+
+    # Returns repository information.
+    def info(about = nil, **opts)
+      array_opts = []
+      array_opts << '--json'     if opts[:json]
+
+      command("info #{about}", array_opts)
     end
 
     def unlock(path = nil)

--- a/lib/extended_git/annex_lib.rb
+++ b/lib/extended_git/annex_lib.rb
@@ -49,7 +49,7 @@ module ExtendedGit
 
     # Makes the content of annexed files available.
     def get(path)
-      command("get #{path}")
+      command("get #{escape(path)}")
     end
 
     def enableremote(name, opts = {})
@@ -77,8 +77,12 @@ module ExtendedGit
     end
 
     # Removes content of files from repository.
-    def drop(path = nil)
-      command("drop #{path}")
+    def drop(path = nil, opts = {})
+      array_opts = []
+      array_opts << "--all" if opts[:all]
+      array_opts << "--force" if opts[:force]
+
+      command("drop #{escape(path)}", array_opts)
     end
 
     def testremote(name, opts = {})

--- a/lib/extended_git/annex_lib.rb
+++ b/lib/extended_git/annex_lib.rb
@@ -144,7 +144,7 @@ module ExtendedGit
       def command(cmd, opts = [])
         # TODO:global config, pointing at correct working path and git dir
         global_opts = []
-        global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
+        global_opts << "--git-dir=#{@git_dir}" if @git_dir
         global_opts << "--work-tree=#{@git_work_dir}" if @git_work_dir
 
         global_opts = global_opts.flatten.join(' ') # TODO: should be escaped?

--- a/lib/extended_git/base.rb
+++ b/lib/extended_git/base.rb
@@ -12,8 +12,10 @@ module ExtendedGit
     # Methods for git annex:
     #   annex.version
     #   annex.init
+    #   annex.uninit
     #   annex.info
     #   annex.get
+    #   annex.sync
     #   annex.unlock
     #   annex.lock
     #   annex.whereis

--- a/lib/extended_git/base.rb
+++ b/lib/extended_git/base.rb
@@ -14,15 +14,14 @@ module ExtendedGit
     #   annex.init
     #   annex.info
     #   annex.get
+    #   annex.unlock
+    #   annex.lock
+    #   annex.whereis
     #   annex.initremote
     #   annex.enableremote
     #   annex.testremote
     def annex
-      ExtendedGit::Annex.new(self)
-    end
-
-    def annex_lib
-      @annex_lib ||= ExtendedGit::AnnexLib.new(self)
+      @annex ||= ExtendedGit::Annex.new(self)
     end
   end
 end

--- a/lib/extended_git/repository_info.rb
+++ b/lib/extended_git/repository_info.rb
@@ -1,0 +1,41 @@
+module ExtendedGit
+  class RepositoryInfo
+
+    attr_reader :remotes
+
+    def initialize(base)
+      @base = base
+
+      construct_remote_info
+    end
+
+    def remote(name) # TODO: Eventually accept UUID
+      remotes.find { |r| r.name == name }
+    end
+
+    def remote?(name)
+      !!remote(name)
+    end
+
+    def construct_remote_info
+      raw_result = @base.annex.lib.info(json: true)
+      result = JSON.parse(raw_result)
+      remotes = result['semitrusted repositories'] + result['trusted repositories'] + result['untrusted repositories']
+
+      @remotes = remotes.map do |remote|
+        remote_result = JSON.parse(@base.annex.lib.info(remote['uuid'], json: true))
+
+        # If needed, can expose more information.
+        OpenStruct.new(
+          uuid: remote['uuid'],
+          here: remote['here'],
+          description: remote['description'],
+          name: remote_result['remote'] || remote['description'], # When the repository is the current one need to use the description.
+          type: remote_result['type'],
+          directory: remote_result['directory'],
+          trust: remote_result['trust']
+        )
+      end
+    end
+  end
+end

--- a/lib/extended_git/where_is.rb
+++ b/lib/extended_git/where_is.rb
@@ -1,0 +1,59 @@
+module ExtendedGit
+  class WhereIs
+    include Enumerable
+
+    attr_reader :files
+
+    def initialize(base, path = nil, options = {})
+      @base = base
+
+      construct_whereis_files(path, options)
+    end
+
+    # enumerable methods
+    def [](file)
+      @files[file]
+    end
+
+    def each(&block)
+      @files.each(&block)
+    end
+
+    class WhereIsFile
+      attr_accessor :name, :locations
+
+      def initialize(json)
+        parsed_json = JSON.parse(json)
+
+        @name = parsed_json['file']
+        @locations = generate_locations(parsed_json['whereis'])
+      end
+
+      # Returns true, if a copy of the file is located in this working directory.
+      def here?
+        @locations.any?(&:here)
+      end
+
+      private
+        def generate_locations(locations)
+          locations.map do |location|
+            OpenStruct.new(
+              description: location['description'],
+              here: location['here'],
+              uuid: location['uuid'],
+              urls: location['urls']
+            )
+          end
+        end
+    end
+
+    private
+
+      def construct_whereis_files(path = nil, options = {})
+        results = @base.annex.lib.whereis(path, json: true, **options)
+
+        # have to divide the results by new line and then each new line can be parsed
+        @files = results.lines.map { |result| WhereIsFile.new(result) }
+      end
+  end
+end

--- a/lib/extended_git/where_is.rb
+++ b/lib/extended_git/where_is.rb
@@ -10,22 +10,26 @@ module ExtendedGit
       construct_whereis_files(path, options)
     end
 
-    # enumerable methods
+    # Enumerable method
+    def each(&block)
+      @files.values.each(&block)
+    end
+
     def [](file)
       @files[file]
     end
 
-    def each(&block)
-      @files.each(&block)
+    def includes_file?(file)
+      @files.key?(file)
     end
 
     class WhereIsFile
-      attr_accessor :name, :locations
+      attr_accessor :filepath, :locations
 
       def initialize(json)
         parsed_json = JSON.parse(json)
 
-        @name = parsed_json['file']
+        @filepath = parsed_json['file']
         @locations = generate_locations(parsed_json['whereis'])
       end
 
@@ -35,6 +39,7 @@ module ExtendedGit
       end
 
       private
+      
         def generate_locations(locations)
           locations.map do |location|
             OpenStruct.new(
@@ -53,7 +58,9 @@ module ExtendedGit
         results = @base.annex.lib.whereis(path, json: true, **options)
 
         # have to divide the results by new line and then each new line can be parsed
-        @files = results.lines.map { |result| WhereIsFile.new(result) }
+        found_files = results.lines.map { |result| WhereIsFile.new(result) }
+
+        @files = found_files.map { |f| [f.filepath, f] }.to_h
       end
   end
 end

--- a/lib/extended_git/where_is.rb
+++ b/lib/extended_git/where_is.rb
@@ -1,3 +1,19 @@
+# Using the `git annex whereis` command finds the location of the set of files
+# described by the path and options. Files that are managed by git-annex may
+# be stored in different location. This class helps confirm the files that are
+# tracked by git-annex and the location of those files.
+#
+# Examples:
+#   git = ExtendedGit.open(directory)
+
+#   To get the location of a specific file without quering for all the files:
+#     git.annex.whereis('filename.txt')['filename.txt'].locations
+#
+#   To get the locations of each file within a directory:
+#     files = git.annex.whereis('directory_name/') # Returns list of files
+#     files.first.locations                        # Returns the locations of the first file
+#     files['specific_file.txt'].locations         # Returns locations of specific file
+
 module ExtendedGit
   class WhereIs
     include Enumerable
@@ -39,7 +55,7 @@ module ExtendedGit
       end
 
       private
-      
+
         def generate_locations(locations)
           locations.map do |location|
             OpenStruct.new(

--- a/lib/utils/process.rb
+++ b/lib/utils/process.rb
@@ -170,6 +170,7 @@ module Utils
       end
 
       repo.save!
+      Dir.chdir(Rails.root.to_s) # FIXME: Eventually remove, when we don't depend on changing the directory
     end
 
     def jettison_originals(repo, working_path, commit_message)

--- a/lib/utils/version_control/git_annex.rb
+++ b/lib/utils/version_control/git_annex.rb
@@ -45,29 +45,6 @@ module Utils
         destination
       end
 
-      # Not used.
-      def reset_hard(dir)
-        change_dir_working(dir)
-        `git reset --hard`
-      end
-
-      # Doesn't seem to be used?
-      def sync(dir)
-        begin
-          change_dir_working(dir)
-          rolling_upgrade(dir)
-          `git annex sync --content`
-        rescue
-          raise I18n.t('colenda.utils.version_control.git_annex.errors.sync')
-        end
-      end
-
-      # Not used.
-      def push_bare(dir)
-        change_dir_working(dir)
-        `git push origin master`
-      end
-
       def push(options, dir)
         git = ExtendedGit.open(dir)
         git.push('origin', 'master')
@@ -78,12 +55,6 @@ module Utils
         else
           git.annex.sync(content: true)
         end
-      end
-
-      # Not used.
-      def pull(dir)
-        change_dir_working(dir)
-        `git pull`
       end
 
       # My current understanding is that all files added either by `git add` or
@@ -113,7 +84,6 @@ module Utils
         return `git annex copy #{Shellwords.escape(content)} #{from} #{to}`
       end
 
-
       def commit(commit_message, dir)
         change_dir_working(dir)
         working_repo = Git.open(dir)
@@ -123,13 +93,6 @@ module Utils
           return if exception.message =~ /nothing \w* commit, working \w* clean/ or exception.message =~ /Changes not staged for commit/ or exception.message == 'Nothing staged for commit.'
           raise Utils::Error::VersionControl.new(error_message(exception.message))
         end
-      end
-
-      # Not used.
-      def commit_bare(commit_message, dir)
-        working_repo = Git.open(dir)
-        working_repo.add(:all => true)
-        working_repo.commit(commit_message)
       end
 
       # TODO: Using `FileUtils.rm_rf` does not raise StandardErrors. We might want to

--- a/spec/extended_git/annex_spec.rb
+++ b/spec/extended_git/annex_spec.rb
@@ -193,6 +193,11 @@ RSpec.describe ExtendedGit::Annex, type: :model do
       git.annex.drop(readme)
       expect(File.exist?(readme_path)).to be false
     end
+
+    it 'drops everything' do
+      git.annex.drop
+      expect(File.exist?(readme_path)).to be false
+    end
   end
 
   describe '#testremote' do

--- a/spec/extended_git/annex_spec.rb
+++ b/spec/extended_git/annex_spec.rb
@@ -1,0 +1,294 @@
+require 'rails_helper'
+
+RSpec.describe ExtendedGit::Annex, type: :model do
+  let(:repo_name) { Faker::File.dir(segment_count: 1) }
+  let(:remote_origin) { Rails.root.join('tmp', repo_name + '.git').to_s }
+  let(:working_directory) { Rails.root.join('tmp', repo_name) }
+
+  let(:git) { ExtendedGit.clone(remote_origin, repo_name, path: Rails.root.join('tmp')) }
+
+  shared_context 'add readme to repository' do
+    let(:readme) { 'README.txt' }
+
+    before do
+      temp = ExtendedGit.clone(remote_origin, repo_name + '_temp', path: Rails.root.join('tmp'))
+      temp.annex.init
+      File.open(File.join(temp.dir.path, readme), 'w') do |f|
+        f.write("README for #{repo_name}")
+      end
+      temp.annex.add(readme)
+      temp.commit("Adding #{readme}")
+      temp.push('origin', 'master') # TODO: Do we need this?
+      temp.push('origin', 'git-annex') # TODO: Do we need this?
+      temp.annex.sync(content: true)
+      temp.annex.uninit
+      FileUtils.rm_r(temp.dir.path)
+    end
+  end
+
+  shared_context 'add directory special remote' do
+    let(:special_remote_name) { 'local_directory' }
+    let(:special_remote_dir) { Rails.root.join('tmp', 'test_special_remote', repo_name).to_s }
+
+    before do
+      FileUtils.mkdir_p(special_remote_dir)
+      temp = ExtendedGit.clone(remote_origin, repo_name + '_temp', path: Rails.root.join('tmp'))
+      temp.annex.init
+      temp.annex.initremote(special_remote_name, type: 'directory', directory: special_remote_dir, encryption: 'none')
+      temp.annex.sync
+      temp.annex.uninit
+      FileUtils.rm_r(temp.dir.path)
+    end
+
+    after do
+      FileUtils.chmod_R(0755, special_remote_dir)
+      FileUtils.rm_r(special_remote_dir)
+    end
+  end
+
+  before do
+    ExtendedGit.init(nil, repository: remote_origin, bare: true)
+  end
+
+  after do
+    # Remove working directory
+    git.annex.uninit if git.config('annex.uuid').present?
+    FileUtils.rm_r(working_directory)
+
+    # Remove remote origin
+    FileUtils.chmod_R(0755, remote_origin)
+    FileUtils.rm_r(remote_origin)
+  end
+
+  describe '#init' do
+    it 'initializes repository with description' do
+      git.annex.init('test_working_directory')
+      expect(git.annex.info.remote?('test_working_directory')).to be true
+    end
+
+    it 'initializes repository with git annex' do
+      git.annex.init
+      expect(git.config('annex.uuid')).not_to be nil
+    end
+  end
+
+  describe '#version' do
+    it 'returns full version output' do
+      expect(git.annex.version).to match(/^git-annex version: \d+\.\d+\.\d+$/)
+    end
+
+    it 'returns raw version output' do
+      expect(git.annex.version(raw: true)).to match(/^\d+\.\d+\.\d+$/)
+    end
+  end
+
+  describe '#add' do
+    # Here because there's a problem with `git.status`, it doesn't work
+    # when there isn't an initial commit.
+    include_context 'add readme to repository'
+
+    let(:filename) { 'new_test_file.txt' }
+    let(:filepath) { File.join(working_directory, filename) }
+
+    before do
+      git.annex.init
+      File.open(filepath, 'w') { |f| f.write("New file -- #{filename}") }
+    end
+
+    it 'adds file to be committed' do
+      git.annex.add(filename)
+      expect(git.status.added?(filename)).to be true
+    end
+
+    it 'adds entire directory to be committed' do
+      git.annex.add('.')
+      expect(git.status.added?(filename)).to be true
+    end
+  end
+
+  describe '#get' do
+    include_context 'add readme to repository'
+
+    before { git.annex.init }
+
+    it 'retrieves file from remote' do
+      expect { git.annex.get(readme) }.not_to raise_error
+      expect(File.exist?(File.join(git.dir.path, readme))).to be true
+    end
+  end
+
+  describe '#enableremote' do
+    include_context 'add readme to repository'
+    include_context 'add directory special remote'
+
+    before do
+      git.annex.init
+      git.annex.enableremote(special_remote_name, directory: special_remote_dir)
+    end
+
+    it 'enables directory remote' do
+      expect(git.config('remote.local_directory.annex-uuid')).to be_truthy
+    end
+  end
+
+  describe '#initremote' do
+    include_context 'add readme to repository'
+    let(:special_remote_name) { 'new_directory' }
+    let(:special_remote_dir) { Rails.root.join('tmp', 'test_special_remote', repo_name).to_s }
+
+    before do
+      FileUtils.mkdir_p(special_remote_dir)
+      git.annex.init
+    end
+
+    after do
+      FileUtils.chmod_R(0755, special_remote_dir)
+      FileUtils.rm_r(special_remote_dir)
+    end
+
+    it 'adds new special remote' do
+      expect {
+        git.annex.initremote(special_remote_name, type: 'directory', directory: special_remote_dir, encryption: 'none')
+      }.not_to raise_error
+      expect(git.annex.info.remote?(special_remote_name)).to be true
+      expect(git.annex.info.remote(special_remote_name).directory).to eql special_remote_dir
+    end
+  end
+
+  # TODO: Not sure how to test that this works. For now just testing that errors aren't
+  # raised.
+  describe '#fsck' do
+    include_context 'add readme to repository'
+    include_context 'add directory special remote'
+
+    before do
+      git.annex.init
+      git.annex.enableremote(special_remote_name, directory: special_remote_dir)
+    end
+
+    it 'checks files' do
+      expect { git.annex.fsck }.not_to raise_error
+    end
+
+    it 'checks files with --fast flag' do
+      expect { git.annex.fsck(fast: true) }.not_to raise_error
+    end
+
+    it 'checks files in special remote with --from flag' do
+      expect { git.annex.fsck(from: special_remote_name) }.not_to raise_error
+    end
+  end
+
+  describe '#drop' do
+    include_context 'add readme to repository'
+    let(:readme_path) { File.join(git.dir.path, readme) }
+
+    before do
+      git.annex.init
+      git.annex.get(readme)
+    end
+
+    it 'drops file' do
+      expect(File.exist?(readme_path)).to be true
+      git.annex.drop(readme)
+      expect(File.exist?(readme_path)).to be false
+    end
+  end
+
+  describe '#testremote' do
+    include_context 'add readme to repository'
+    include_context 'add directory special remote'
+
+    before do
+      git.annex.init
+      git.annex.enableremote(special_remote_name, directory: special_remote_dir)
+    end
+
+    it 'testremote' do
+      expect { git.annex.testremote(special_remote_name) }.not_to raise_error
+    end
+  end
+
+  describe '#whereis' do
+    include_context 'add readme to repository'
+
+    before { git.annex.init }
+
+    it 'returns information about readme' do
+      result = git.annex.whereis(readme)
+      expect(result).to be_a ExtendedGit::WhereIs
+      expect(result[readme]).to be_a ExtendedGit::WhereIs::WhereIsFile
+    end
+  end
+
+  describe '#info' do
+    before { git.annex.init }
+
+    it 'returns information' do
+      expect(git.annex.info).to be_a ExtendedGit::RepositoryInfo
+    end
+  end
+
+  describe '#lock' do
+    include_context 'add readme to repository'
+
+    before do
+      git.annex.init
+      git.annex.get(readme)
+      git.annex.unlock(readme)
+    end
+
+    it 'locks file' do
+      expect(git.annex.whereis(unlocked: true).includes_file?(readme)).to be true
+      git.annex.lock(readme)
+      expect(git.annex.whereis(locked: true).includes_file?(readme)).to be true
+    end
+  end
+
+  describe '#unlocked' do
+    include_context 'add readme to repository'
+
+    before do
+      git.annex.init
+      git.annex.get(readme)
+    end
+
+    it 'unlock file' do
+      expect(git.annex.whereis(locked: true).includes_file?(readme)).to be true
+      git.annex.unlock(readme)
+      expect(git.annex.whereis(unlocked: true).includes_file?(readme)).to be true
+    end
+  end
+
+  describe '#sync' do
+    include_context 'add readme to repository'
+    include_context 'add directory special remote'
+
+    before do
+      git.annex.init
+      git.annex.enableremote(special_remote_name, directory: special_remote_dir)
+    end
+
+    it 'syncs content' do
+      expect { git.annex.sync(content: true) }.not_to raise_error
+      expect(git.annex.whereis[readme].here?).to be true
+      expect(git.annex.whereis[readme].locations.map(&:description)).to include("[#{special_remote_name}]")
+    end
+  end
+
+  describe '#copy' do
+    include_context 'add readme to repository'
+    include_context 'add directory special remote'
+
+    before do
+      git.annex.init
+      git.annex.get(readme)
+      git.annex.enableremote(special_remote_name, directory: special_remote_dir)
+    end
+
+    it 'copies file to special remote' do
+      expect { git.annex.copy(readme, to: special_remote_name) }.not_to raise_error
+      expect(git.annex.whereis[readme].locations.map(&:description)).to include("[#{special_remote_name}]")
+    end
+  end
+end

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Repo, type: :model do
         end
 
         it 'special remote is configured in remote repo' do
-          expect(working_repo.annex.info('local')).not_to match /failed/
+          expect(working_repo.annex.info.remote?('local')).to be true
         end
 
         context 'when setting up special remote' do

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -123,4 +123,38 @@ RSpec.describe Repo, type: :model do
       expect(File.exists?(readme_path)).to be true
     end
   end
+
+  describe '#_build_and_populate_directories' do
+    let(:repo) { FactoryBot.create(:repo) }
+    let(:directory) { Rails.root.join('tmp', 'test_directory') }
+
+    before do
+      FileUtils.mkdir_p(directory)
+      repo.send('_build_and_populate_directories', directory)
+    end
+
+    after { FileUtils.remove_dir(directory) }
+
+    it 'creates README.md file' do
+      expect(File.exist?(File.join(directory, 'README.md')))
+    end
+
+    it 'creates init script' do
+      expect(File.exist?(File.join(directory, '.repoadmin', 'bin', 'init.sh'))).to be true
+    end
+
+    it 'creates expected directories' do
+      expect(File.directory?(File.join(directory, '.derivs'))).to be true
+      expect(File.directory?(File.join(directory, '.repoadmin'))).to be true
+      expect(File.directory?(File.join(directory, 'data'))).to be true
+      expect(File.directory?(File.join(directory, 'data', 'metadata'))).to be true
+      expect(File.directory?(File.join(directory, 'data', 'assets'))).to be true
+    end
+
+    it 'creates expected .keep files' do
+      expect(File.exist?(File.join(directory, 'data', 'metadata', '.keep'))).to be true
+      expect(File.exist?(File.join(directory, 'data', 'assets', '.keep'))).to be true
+      expect(File.exist?(File.join(directory, '.derivs', '.keep'))).to be true
+    end
+  end
 end

--- a/spec/utils/version_control/git_annex_spec.rb
+++ b/spec/utils/version_control/git_annex_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe Utils::VersionControl::GitAnnex do
       before { git_annex.push({}, cloned_repo_path) }
 
       it 'content is stored in special remote' do
-        expect(git.annex.whereis(first_new_file).first.locations.map(&:description)).to include '[local]'
-        expect(git.annex.whereis(second_new_file).first.locations.map(&:description)).to include '[local]'
+        expect(git.annex.whereis[first_new_file].locations.map(&:description)).to include '[local]'
+        expect(git.annex.whereis[second_new_file].locations.map(&:description)).to include '[local]'
       end
     end
 
@@ -117,11 +117,11 @@ RSpec.describe Utils::VersionControl::GitAnnex do
       end
 
       it 'expected content is stored in special remote' do
-        expect(git.annex.whereis(second_new_file).first.locations.map(&:description)).to include '[local]'
+        expect(git.annex.whereis[second_new_file].locations.map(&:description)).to include '[local]'
       end
 
       it 'expected content is NOT stored in special remote' do
-        expect(git.annex.whereis(first_new_file).first.locations.map(&:description)).not_to include '[local]'
+        expect(git.annex.whereis[first_new_file].locations.map(&:description)).not_to include '[local]'
       end
     end
   end
@@ -161,8 +161,8 @@ RSpec.describe Utils::VersionControl::GitAnnex do
       before { git_annex.drop({ content: filename }, cloned_repo_path) }
 
       it 'only drops README.md' do
-        expect(git.annex.whereis(filename).first.here?).to be false # README.md dropped.
-        expect(git.annex.whereis(new_file).first.here?).to be true # Other files NOT dropped.
+        expect(git.annex.whereis[filename].here?).to be false # README.md dropped.
+        expect(git.annex.whereis[new_file].here?).to be true # Other files NOT dropped.
       end
     end
 
@@ -193,7 +193,7 @@ RSpec.describe Utils::VersionControl::GitAnnex do
 
       it 'does not have references to old working repo' do
         expect(
-          new_clone.annex.whereis('README.md').first.locations.map(&:uuid)
+          new_clone.annex.whereis['README.md'].locations.map(&:uuid)
         ).not_to include cloned_repo_annex_uuid
       end
     end
@@ -226,16 +226,16 @@ RSpec.describe Utils::VersionControl::GitAnnex do
       expect(File.exist?(File.join(cloned_repo_path, 'README.md'))).to be false
       git_annex.get({ location: 'README.md'}, cloned_repo_path)
       expect(File.exist?(File.join(cloned_repo_path, 'README.md'))).to be true
-      expect(git.annex.whereis('README.md').first.here?).to be true
+      expect(git.annex.whereis['README.md'].here?).to be true
     end
 
     it 'retrieves all files within directory' do
       expect(git.annex.whereis.any?(&:here?)).to be false
       git_annex.get({ location: File.join(cloned_repo_path, 'data', 'assets') }, cloned_repo_path)
       FileUtils.chdir(cloned_repo_path) # `get` changes the directory, have to change it back.
-      expect(git.annex.whereis(first_file).first.here?).to be true
-      expect(git.annex.whereis(second_file).first.here?).to be true
-      expect(git.annex.whereis('README.md').first.here?).to be false
+      expect(git.annex.whereis[first_file].here?).to be true
+      expect(git.annex.whereis[second_file].here?).to be true
+      expect(git.annex.whereis['README.md'].here?).to be false
     end
 
     it 'retrieves all files' do
@@ -251,9 +251,9 @@ RSpec.describe Utils::VersionControl::GitAnnex do
     let(:git) { ExtendedGit.open(cloned_repo_path) }
 
     it 'unlocks file' do
-      expect(git.annex.whereis(locked: true).files.map(&:name)).to include 'README.md'
+      expect(git.annex.whereis(locked: true).includes_file?('README.md')).to be true
       git_annex.unlock({ content: 'README.md' }, cloned_repo_path)
-      expect(git.annex.whereis(unlocked: true).files.map(&:name)).to include 'README.md'
+      expect(git.annex.whereis(unlocked: true).includes_file?('README.md')).to be true
     end
   end
 
@@ -264,9 +264,9 @@ RSpec.describe Utils::VersionControl::GitAnnex do
     before { git.annex.unlock('README.md') }
 
     it 'locks file' do
-      expect(git.annex.whereis(unlocked: true).files.map(&:name)).to include 'README.md'
+      expect(git.annex.whereis(unlocked: true).includes_file?('README.md')).to be true
       git_annex.lock('README.md', cloned_repo_path)
-      expect(git.annex.whereis(locked: true).files.map(&:name)).to include 'README.md'
+      expect(git.annex.whereis(locked: true).includes_file?('README.md')).to be true
     end
   end
 end

--- a/spec/utils/version_control/git_annex_spec.rb
+++ b/spec/utils/version_control/git_annex_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Utils::VersionControl::GitAnnex do
     let(:cloned_repo_path) { git_annex.clone }
     let(:git) { ExtendedGit.open(cloned_repo_path) }
 
+    after { git_annex.remove_working_directory(cloned_repo_path) }
+
     it 'is a working directory' do
       expect(ExtendedGit.is_working_directory?(cloned_repo_path)).to be true
     end
@@ -36,6 +38,235 @@ RSpec.describe Utils::VersionControl::GitAnnex do
     it 'adds git configuration' do
       expect(git.config('remote.origin.annex-ignore')).to eq 'true'
       expect(git.config('annex.largefiles')).to eq 'not (include=.repoadmin/bin/*.sh)'
+    end
+  end
+
+  describe '#add' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:new_file_path) { File.join(cloned_repo_path, 'new_file.txt') }
+
+    after { git_annex.remove_working_directory(cloned_repo_path) }
+
+    [:store, :git].each do |type|
+      before do
+        FileUtils.touch(new_file_path)
+        git_annex.add({ content: new_file_path, add_type: type }, cloned_repo_path)
+      end
+
+      it "adds files when adding through #{type}" do
+        git = ExtendedGit.open(cloned_repo_path)
+        expect(git.status.added?('new_file.txt')).to be true
+      end
+    end
+  end
+
+  describe '#commit' do
+    after { git_annex.remove_working_directory(cloned_repo_path) }
+
+    context 'after adding a file' do
+      let(:cloned_repo_path) { git_annex.clone }
+      let(:git) { ExtendedGit.open(cloned_repo_path) }
+      let(:commit_message) { 'New commit.' }
+
+      before do
+        new_file_path = File.join(cloned_repo_path, 'new_file.txt')
+        FileUtils.touch(new_file_path)
+        git.add(new_file_path)
+        git_annex.commit(commit_message, cloned_repo_path)
+      end
+
+      it 'correctly commits new file' do
+        expect(git.log.first.message).to eql commit_message
+        expect(git.status['new_file.txt']).not_to be nil
+        expect(git.status.untracked?('new_file.txt')).to be false
+      end
+    end
+  end
+
+  describe '#push' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:git) { ExtendedGit.open(cloned_repo_path) }
+    let(:first_new_file) { 'first_new_file.txt' }
+    let(:second_new_file) { 'second_new_file.txt' }
+
+    before do
+      [first_new_file, second_new_file].each do |new_file|
+        new_file_path = File.join(cloned_repo_path, new_file )
+        # Each file needs to have different content.
+        File.open(new_file_path, 'w') { |f| f.write("New file -- #{new_file}") }
+        git.add(new_file_path)
+      end
+
+      git_annex.commit('New files.', cloned_repo_path)
+    end
+
+    after { git_annex.remove_working_directory(cloned_repo_path) }
+
+    context 'when pushing all new content' do
+      before { git_annex.push({}, cloned_repo_path) }
+
+      it 'content is stored in special remote' do
+        expect(git.annex.whereis(first_new_file).first.locations.map(&:description)).to include '[local]'
+        expect(git.annex.whereis(second_new_file).first.locations.map(&:description)).to include '[local]'
+      end
+    end
+
+    context 'when only pushing specified content' do
+      before do
+        git_annex.push({ content: second_new_file }, cloned_repo_path)
+      end
+
+      it 'expected content is stored in special remote' do
+        expect(git.annex.whereis(second_new_file).first.locations.map(&:description)).to include '[local]'
+      end
+
+      it 'expected content is NOT stored in special remote' do
+        expect(git.annex.whereis(first_new_file).first.locations.map(&:description)).not_to include '[local]'
+      end
+    end
+  end
+
+  describe '#drop' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:git) { ExtendedGit.open(cloned_repo_path) }
+    let(:new_file) { 'new_file.txt' }
+
+    # Adding an additional file.
+    before do
+      new_file_path = File.join(cloned_repo_path, new_file)
+      FileUtils.touch(new_file_path)
+      git.add(new_file_path)
+      git_annex.commit('Adding new file.', cloned_repo_path)
+      git_annex.push({}, cloned_repo_path)
+    end
+
+    after { git_annex.remove_working_directory(cloned_repo_path) }
+
+    # Checking that files are present in working directory.
+    it 'contains files in current working directory' do
+      expect(git.annex.whereis.all?(&:here?)).to be true
+    end
+
+    context 'when dropping everything' do
+      before { git_annex.drop({}, cloned_repo_path) }
+
+      it 'drops all files' do
+        expect(git.annex.whereis.any?(&:here?)).to be false
+      end
+    end
+
+    context 'when dropping specific content' do
+      let(:filename) { 'README.md' }
+
+      before { git_annex.drop({ content: filename }, cloned_repo_path) }
+
+      it 'only drops README.md' do
+        expect(git.annex.whereis(filename).first.here?).to be false # README.md dropped.
+        expect(git.annex.whereis(new_file).first.here?).to be true # Other files NOT dropped.
+      end
+    end
+
+    context 'when imaging user configured' do
+      it 'changes permissions'
+    end
+  end
+
+  describe '#remove_working_directory' do
+    let!(:cloned_repo_path) { git_annex.clone }
+    let!(:cloned_repo) { ExtendedGit.open(cloned_repo_path) }
+    let!(:cloned_repo_annex_uuid) { cloned_repo.config('annex.uuid') }
+
+    before do
+      cloned_repo.annex.get('README.md')
+      git_annex.remove_working_directory(cloned_repo_path)
+    end
+
+    context 'when cloning repository again' do
+      let(:temp_location) { Rails.root.join('tmp', 'test_directory') }
+      let(:new_clone) do
+        new_clone = ExtendedGit.clone(git_annex.remote_repo_path, temp_location)
+        new_clone.annex.init
+        new_clone
+      end
+
+      after { FileUtils.remove_dir(new_clone.dir.path) }
+
+      it 'does not have references to old working repo' do
+        expect(
+          new_clone.annex.whereis('README.md').first.locations.map(&:uuid)
+        ).not_to include cloned_repo_annex_uuid
+      end
+    end
+
+    it 'deletes directory' do
+      expect(File.directory?(cloned_repo_path)).to be false
+    end
+  end
+
+  describe '#get' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:git) { ExtendedGit.open(cloned_repo_path) }
+
+    let(:first_file) { File.join('data', 'assets', 'new_file.txt') }
+    let(:second_file) { File.join('data', 'assets', 'other_new_file.txt') }
+
+    # Adding files to remote and special remote, then dropping them to test `get`.
+    before do
+      [first_file, second_file].each do |file|
+        new_file_path = File.join(cloned_repo_path, file)
+        File.open(new_file_path, 'w') { |f| f.write("New file -- #{file}") }
+        git.add(new_file_path)
+      end
+      git_annex.commit('Adding new files.', cloned_repo_path)
+      git_annex.push({}, cloned_repo_path)
+      git_annex.drop({}, cloned_repo_path)
+    end
+
+    it 'retrieves a file' do
+      expect(File.exist?(File.join(cloned_repo_path, 'README.md'))).to be false
+      git_annex.get({ location: 'README.md'}, cloned_repo_path)
+      expect(File.exist?(File.join(cloned_repo_path, 'README.md'))).to be true
+      expect(git.annex.whereis('README.md').first.here?).to be true
+    end
+
+    it 'retrieves all files within directory' do
+      expect(git.annex.whereis.any?(&:here?)).to be false
+      git_annex.get({ location: File.join(cloned_repo_path, 'data', 'assets') }, cloned_repo_path)
+      FileUtils.chdir(cloned_repo_path) # `get` changes the directory, have to change it back.
+      expect(git.annex.whereis(first_file).first.here?).to be true
+      expect(git.annex.whereis(second_file).first.here?).to be true
+      expect(git.annex.whereis('README.md').first.here?).to be false
+    end
+
+    it 'retrieves all files' do
+      expect(git.annex.whereis.any?(&:here?)).to be false
+      git_annex.get({ location: '.' }, cloned_repo_path)
+      FileUtils.chdir(cloned_repo_path) # `get` changes the directory, have to change it back.
+      expect(git.annex.whereis.all?(&:here?)).to be true
+    end
+  end
+
+  describe '#unlock' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:git) { ExtendedGit.open(cloned_repo_path) }
+
+    it 'unlocks file' do
+      expect(git.annex.whereis(locked: true).files.map(&:name)).to include 'README.md'
+      git_annex.unlock({ content: 'README.md' }, cloned_repo_path)
+      expect(git.annex.whereis(unlocked: true).files.map(&:name)).to include 'README.md'
+    end
+  end
+
+  describe '#lock' do
+    let(:cloned_repo_path) { git_annex.clone }
+    let(:git) { ExtendedGit.open(cloned_repo_path) }
+
+    before { git.annex.unlock('README.md') }
+
+    it 'locks file' do
+      expect(git.annex.whereis(unlocked: true).files.map(&:name)).to include 'README.md'
+      git_annex.lock('README.md', cloned_repo_path)
+      expect(git.annex.whereis(locked: true).files.map(&:name)).to include 'README.md'
     end
   end
 end


### PR DESCRIPTION
- Adding more tests for `ExtendedGit` methods.
- Adding more tests for `Utils::VersionControl::GitAnnex`
- Replacing more shelled out git-annex commands with `ExtendedGit` calls
- Attempting to concentrate code that depends on being in a certain directory. Changing the directory leads to unintended consequences in other parts of the code.
- Added classes to `ExtendedGit` that parse output provided by git-annex commands. This addition allows for clearer tests.
- Deleted unused methods. 

In a future PR, I plan to refactor the `Utils::VersionControl::GitAnnex` to work slightly different. I can provide more details if that would be helpful. That probably won't be until more extensive testing of manifest loads.
