### PR TITLE
No longer assuming that the first metadata object is the descriptive metadata in fetch_image_ids request

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -53,7 +53,7 @@ class ReposController < ApplicationController
   end
 
   def fetch_image_ids
-    repo = Repo.where(:unique_identifier => "ark:/#{params[:id].tr('-','/')}").first
+    repo = Repo.find_by(unique_identifier: "ark:/#{params[:id].tr('-','/')}")
     result = {}
 
     unless repo.nil?
@@ -63,12 +63,12 @@ class ReposController < ApplicationController
         ids = legacy_image_list(repo)
       end
       ids.map! { |id| id.gsub(ENV['IIIF_IMAGE_SERVER'], '').gsub(/^[^=]*=/, '').gsub('/info.json', '') } unless ids.is_a? Hash
-      title = [repo.metadata_builder.metadata_source.first.user_defined_mappings['title']].flatten.join("; ")
+      title = [repo.descriptive_metadata.user_defined_mappings['title']].flatten.join("; ")
       reading_direction = repo.images_to_render['iiif'].present? ? repo.images_to_render['iiif']['reading_direction'] : "left-to-right"
-      result = { :id => params[:id], :title => title, :reading_direction => reading_direction, :image_ids => ids }
+      result = { id: params[:id], title: title, reading_direction: reading_direction, image_ids: ids }
     end
 
-    render :json => JSON(result)
+    render json: JSON(result)
   end
 
   private

--- a/app/models/metadata_source.rb
+++ b/app/models/metadata_source.rb
@@ -2,8 +2,10 @@ require 'open-uri'
 require 'csv_xlsx_converter'
 
 class MetadataSource < ActiveRecord::Base
-
   include Utils::Artifacts::InputFormats
+
+  STRUCTURAL_TYPES = %w[custom structural_bibid pap_structural kaplan_structural pqc_ark pqc_combined_struct pqc_structural]
+  DESCRIPTIVE_TYPES = %w[kaplan pap pqc_combined_desc pqc_desc voyager pqc]
 
   attr_accessor :xml_header, :xml_footer
   attr_accessor :user_defined_mappings

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -389,6 +389,20 @@ class Repo < ActiveRecord::Base
     self.save!
   end
 
+  # Returning MetadataSource that contains structural metadata.
+  def structural_metadata
+    metadata_builder.metadata_source.find do |metadata|
+      MetadataSource::STRUCTURAL_TYPES.include?(metadata.source_type)
+    end
+  end
+
+  # Returning MetadataSource that contains descriptive metadata.
+  def descriptive_metadata
+    source = metadata_builder.metadata_source.find do |metadata|
+      MetadataSource::DESCRIPTIVE_TYPES.include?(metadata.source_type)
+    end
+  end
+
   private
 
   def _build_and_populate_directories(working_path)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -391,16 +391,12 @@ class Repo < ActiveRecord::Base
 
   # Returning MetadataSource that contains structural metadata.
   def structural_metadata
-    metadata_builder.metadata_source.find do |metadata|
-      MetadataSource::STRUCTURAL_TYPES.include?(metadata.source_type)
-    end
+    metadata_builder.metadata_source.find_by(source_type: MetadataSource::STRUCTURAL_TYPES)
   end
 
   # Returning MetadataSource that contains descriptive metadata.
   def descriptive_metadata
-    source = metadata_builder.metadata_source.find do |metadata|
-      MetadataSource::DESCRIPTIVE_TYPES.include?(metadata.source_type)
-    end
+    metadata_builder.metadata_source.find_by(source_type: MetadataSource::DESCRIPTIVE_TYPES)
   end
 
   private

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -157,4 +157,30 @@ RSpec.describe Repo, type: :model do
       expect(File.exist?(File.join(directory, '.derivs', '.keep'))).to be true
     end
   end
+
+  describe '#structural_metadata' do
+    let(:repo) { FactoryBot.create(:repo) }
+    before do
+      MetadataSource.create(source_type: 'kaplan_structural', metadata_builder: repo.metadata_builder)
+      repo.reload
+    end
+
+    it 'return expected metadata_source' do
+      expect(repo.structural_metadata).to be_a MetadataSource
+      expect(repo.structural_metadata.source_type).to eql 'kaplan_structural'
+    end
+  end
+
+  describe '#descriptive_metadata' do
+    let(:repo) { FactoryBot.create(:repo) }
+    before do
+      MetadataSource.create(source_type: 'pqc', metadata_builder: repo.metadata_builder)
+      repo.reload
+    end
+
+    it 'return expected metadata_source' do
+      expect(repo.descriptive_metadata).to be_a MetadataSource
+      expect(repo.descriptive_metadata.source_type).to eql 'pqc'
+    end
+  end
 end

--- a/spec/requests/repos_controller_spec.rb
+++ b/spec/requests/repos_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ReposController, type: :request do
+  describe '#fetch_image_ids' do
+    let(:repo) { FactoryBot.create(:repo) }
+
+    before do
+      ENV['IIIF_IMAGE_SERVER'] = 'https://colenda.library.upenn.edu/phalt/iiif/2/'
+      # add images to render hash
+      repo.images_to_render = {
+        'iiif' => {
+          'reading_direction' => 'left-to-right',
+          'images' => [
+            'https://colenda.library.upenn.edu/phalt/iiif/2//ark81431p3348gn33%2FSHA256E-s4031202--d312b4a5ef5cf37391e17f6378dcf0c84a06823d4136b2ca941c8102b2335a91.tif.jpeg/info.json',
+            'https://colenda.library.upenn.edu/phalt/iiif/2//ark81431p3348gn33%2FSHA256E-s3777716--bd9ef5508f78c9bcc5bcb867c6533cea6f9bfcd37dc4e4ae398fef513c576c94.tif.jpeg/info.json'
+          ]
+        }
+      }
+      repo.save
+
+      # add descriptive metadata
+      MetadataSource.create(
+        source_type: 'pqc',
+        user_defined_mappings: { 'title' => ['Legal document; Charleston, South Carolina, United States; 1798 April 5'] },
+        metadata_builder: repo.metadata_builder
+      )
+      repo.reload
+
+      get "/repos/#{repo.names.fedora}/fetch_image_ids"
+    end
+
+    after do
+      ENV['IIIF_IMAGE_SERVER'] = ''
+    end
+
+    it 'returns expected response' do
+      expect(JSON.parse(response.body)).to eql(
+        {
+          'id' => repo.names.fedora,
+          'title' => 'Legal document; Charleston, South Carolina, United States; 1798 April 5',
+          'reading_direction' => 'left-to-right',
+          'image_ids' => [
+            '/ark81431p3348gn33%2FSHA256E-s4031202--d312b4a5ef5cf37391e17f6378dcf0c84a06823d4136b2ca941c8102b2335a91.tif.jpeg',
+            '/ark81431p3348gn33%2FSHA256E-s3777716--bd9ef5508f78c9bcc5bcb867c6533cea6f9bfcd37dc4e4ae398fef513c576c94.tif.jpeg'
+          ]
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Creating helpers to retrieve descriptive and structural metadata objects and using those to retrieve the metadata desired. Adding tests for new methods created and adding basic request specs for fetch_image_ids.