### PR TITLE
Restructure sidekiq containers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 5
+:concurrency: 1
 :logfile: ./log/sidekiq.log
 :queues:
   - [file_checks, 1]
@@ -8,4 +8,6 @@
   - [process_manifest, 1]
   - [process_batch, 1]
   - [maintenance, 1]
+  - [xml, 1]
+  - [metadata_extraction, 1]
 :max_retries: 0

--- a/config/sidekiq_metadata.yml
+++ b/config/sidekiq_metadata.yml
@@ -1,5 +1,0 @@
-:concurrency: 1
-:logfile: ./log/sidekiq_metadata.log
-:queues:
-  - [metadata_extraction, 1]
-:max_retries: 0

--- a/config/sidekiq_xml.yml
+++ b/config/sidekiq_xml.yml
@@ -1,5 +1,0 @@
-:concurrency: 1
-:logfile: ./log/sidekiq_xml.log
-:queues:
-  - [xml, 1]
-:max_retries: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,10 @@ services:
   sidekiq:
     image: 'quay.io/upennlibraries/bulwark:${BULWARK_IMAGE_TAG}'
     command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq.yml"
+    deploy:
+      replicas: 3
+      update_config:
+        parallelism: 1
     environment:
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
@@ -238,86 +242,6 @@ services:
       STORAGE_TYPE:
       VOYAGER_HTTP_LOOKUP:
       VOYAGER_STRUCTURAL_HTTP_LOOKUP:
-    ports:
-      - '25:25'
-    secrets:
-      - source: bulwark_database_config
-        target: /home/app/webapp/config/database.yml
-      - source: bulwark_secrets_config
-        target: /home/app/webapp/config/secrets.yml
-    volumes:
-      - '${LOCAL_DATA}:${REMOTE_DATA}'
-      - '${OPENN_HARVESTING_ENDPOINT_LOCAL}:${OPENN_HARVESTING_ENDPOINT_REMOTE}'
-      - '${KAPLAN_HARVESTING_ENDPOINT_LOCAL}:${KAPLAN_HARVESTING_ENDPOINT_REMOTE}'
-      - 'mastersrbm:${MASTERSRBM_HARVESTING_ENDPOINT_REMOTE}'
-      - 'sceti_completed_2:${SCETI_COMPLETED_2_HARVESTING_ENDPOINT_REMOTE}'
-      - 'sceti_completed_3:${SCETI_COMPLETED_3_HARVESTING_ENDPOINT_REMOTE}'
-      - 'scanstore_rescue:${SCANSTORE_RESCUE_HARVESTING_ENDPOINT_REMOTE}'
-      - 'kaplan_rescue:${KAPLAN_RESCUE_HARVESTING_ENDPOINT_REMOTE}'
-      - 'colenda_workspace:${REMOTE_WORKSPACE}'
-  sidekiq_xml:
-    image: 'quay.io/upennlibraries/bulwark:${BULWARK_IMAGE_TAG}'
-    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq.yml"
-    environment:
-      AWS_ACCESS_KEY_ID:
-      AWS_SECRET_ACCESS_KEY:
-      BATCH_OPS_EMAIL:
-      CACHE_URL:
-      CATALOG_CONTROLLER_PROTOCOL:
-      DATABASE_NAME:
-      DATABASE_USERNAME:
-      ERC_DEFAULT_WHO:
-      EZID_DEFAULT_SHOULDER:
-      EZID_PASSWORD:
-      EZID_USER:
-      GIT_USER:
-      GIT_USER_PASS:
-      IIIF_IMAGE_SERVER:
-      IMAGING_USER:
-      IMAGING_USER_PASS:
-      KAPLAN_HARVESTING_ENDPOINT_REMOTE:
-      KAPLAN_INITIAL_STOP:
-      KAPLAN_OWNER:
-      KAPLAN_RESCUE_HARVESTING_ENDPOINT_REMOTE:
-      MASTERSRBM_HARVESTING_ENDPOINT_REMOTE:
-      OPENN_DESCRIPTION:
-      OPENN_HARVESTING_ENDPOINT_REMOTE:
-      OPENN_INITIAL_STOP:
-      OPENN_OWNER:
-      PAP_DESCRIPTION:
-      PAP_HARVESTING_ENDPOINT_REMOTE:
-      PAP_HTTP_LOOKUP:
-      PAP_STRUCTURAL_HTTP_LOOKUP:
-      PAP_INITIAL_STOP:
-      PAP_OWNER:
-      PHALT_ENDPOINT:
-      PROD_FEDORA_PW:
-      PROD_FEDORA_URL:
-      PROD_FEDORA_USER:
-      PROD_SOLR_URL:
-      PUBLIC_FEDORA_URL:
-      RAILS_ENV:
-      REDIS_URL:
-      REQUEST_STYLE:
-      SCANSTORE_RESCUE_HARVESTING_ENDPOINT_REMOTE:
-      SCETI_COMPLETED_2_HARVESTING_ENDPOINT_REMOTE:
-      SCETI_COMPLETED_3_HARVESTING_ENDPOINT_REMOTE:
-      SMTP_ADDRESS:
-      SMTP_DOMAIN:
-      SMTP_PORT:
-      SPECIAL_REMOTE_NAME:
-      STORAGE_ENCRYPTION:
-      STORAGE_HOST:
-      STORAGE_PORT:
-      STORAGE_PROTOCOL:
-      STORAGE_PUBLIC:
-      STORAGE_READ_HOST:
-      STORAGE_READ_PROTOCOL:
-      STORAGE_TYPE:
-      VOYAGER_HTTP_LOOKUP:
-      VOYAGER_STRUCTURAL_HTTP_LOOKUP:
-    ports:
-      - '26:25'
     secrets:
       - source: bulwark_database_config
         target: /home/app/webapp/config/database.yml
@@ -338,84 +262,6 @@ services:
     hostname: 'rabbitmq'
     ports:
       - '15672:15672'
-  sidekiq_metadata:
-    image: 'quay.io/upennlibraries/bulwark:${BULWARK_IMAGE_TAG}'
-    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq.yml"
-    environment:
-      AWS_ACCESS_KEY_ID:
-      AWS_SECRET_ACCESS_KEY:
-      BATCH_OPS_EMAIL:
-      CACHE_URL:
-      CATALOG_CONTROLLER_PROTOCOL:
-      DATABASE_NAME:
-      DATABASE_USERNAME:
-      ERC_DEFAULT_WHO:
-      EZID_DEFAULT_SHOULDER:
-      EZID_PASSWORD:
-      EZID_USER:
-      GIT_USER:
-      GIT_USER_PASS:
-      IIIF_IMAGE_SERVER:
-      IMAGING_USER:
-      IMAGING_USER_PASS:
-      KAPLAN_HARVESTING_ENDPOINT_REMOTE:
-      KAPLAN_INITIAL_STOP:
-      KAPLAN_OWNER:
-      KAPLAN_RESCUE_HARVESTING_ENDPOINT_REMOTE:
-      MASTERSRBM_HARVESTING_ENDPOINT_REMOTE:
-      OPENN_DESCRIPTION:
-      OPENN_HARVESTING_ENDPOINT_REMOTE:
-      OPENN_INITIAL_STOP:
-      OPENN_OWNER:
-      PAP_DESCRIPTION:
-      PAP_HARVESTING_ENDPOINT_REMOTE:
-      PAP_HTTP_LOOKUP:
-      PAP_STRUCTURAL_HTTP_LOOKUP:
-      PAP_INITIAL_STOP:
-      PAP_OWNER:
-      PHALT_ENDPOINT:
-      PROD_FEDORA_PW:
-      PROD_FEDORA_URL:
-      PROD_FEDORA_USER:
-      PROD_SOLR_URL:
-      PUBLIC_FEDORA_URL:
-      RAILS_ENV:
-      REDIS_URL:
-      REQUEST_STYLE:
-      SCANSTORE_RESCUE_HARVESTING_ENDPOINT_REMOTE:
-      SCETI_COMPLETED_2_HARVESTING_ENDPOINT_REMOTE:
-      SCETI_COMPLETED_3_HARVESTING_ENDPOINT_REMOTE:
-      SMTP_ADDRESS:
-      SMTP_DOMAIN:
-      SMTP_PORT:
-      SPECIAL_REMOTE_NAME:
-      STORAGE_ENCRYPTION:
-      STORAGE_HOST:
-      STORAGE_PORT:
-      STORAGE_PROTOCOL:
-      STORAGE_PUBLIC:
-      STORAGE_READ_HOST:
-      STORAGE_READ_PROTOCOL:
-      STORAGE_TYPE:
-      VOYAGER_HTTP_LOOKUP:
-      VOYAGER_STRUCTURAL_HTTP_LOOKUP:
-    ports:
-      - '27:25'
-    secrets:
-      - source: bulwark_database_config
-        target: /home/app/webapp/config/database.yml
-      - source: bulwark_secrets_config
-        target: /home/app/webapp/config/secrets.yml
-    volumes:
-      - '${LOCAL_DATA}:${REMOTE_DATA}'
-      - '${OPENN_HARVESTING_ENDPOINT_LOCAL}:${OPENN_HARVESTING_ENDPOINT_REMOTE}'
-      - '${KAPLAN_HARVESTING_ENDPOINT_LOCAL}:${KAPLAN_HARVESTING_ENDPOINT_REMOTE}'
-      - 'mastersrbm:${MASTERSRBM_HARVESTING_ENDPOINT_REMOTE}'
-      - 'sceti_completed_2:${SCETI_COMPLETED_2_HARVESTING_ENDPOINT_REMOTE}'
-      - 'sceti_completed_3:${SCETI_COMPLETED_3_HARVESTING_ENDPOINT_REMOTE}'
-      - 'scanstore_rescue:${SCANSTORE_RESCUE_HARVESTING_ENDPOINT_REMOTE}'
-      - 'kaplan_rescue:${KAPLAN_RESCUE_HARVESTING_ENDPOINT_REMOTE}'
-      - 'colenda_workspace:${REMOTE_WORKSPACE}'
 
 volumes:
   colenda_workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,7 +257,7 @@ services:
       - 'colenda_workspace:${REMOTE_WORKSPACE}'
   sidekiq_xml:
     image: 'quay.io/upennlibraries/bulwark:${BULWARK_IMAGE_TAG}'
-    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq_xml.yml"
+    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq.yml"
     environment:
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:
@@ -340,7 +340,7 @@ services:
       - '15672:15672'
   sidekiq_metadata:
     image: 'quay.io/upennlibraries/bulwark:${BULWARK_IMAGE_TAG}'
-    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq_metadata.yml"
+    command: bash -c "/etc/my_init.d/gitannex.sh && /etc/my_init.d/imaging.sh && /sbin/my_init --skip-startup-files --skip-runit -- bundle exec sidekiq -C config/sidekiq.yml"
     environment:
       AWS_ACCESS_KEY_ID:
       AWS_SECRET_ACCESS_KEY:


### PR DESCRIPTION
I would like to restructure Bulwark's Sidekiq containers so that each container only runs one thread, but can run jobs for all the queues. We are seeing potential thread-safety issues so I am hoping this stops these issues until we can figure out what exactly the problems are.

Can move away from specifying each Sidekiq container separately and instead setting the number of replicas to 3? 

I've deployed these changes to dev and works as expected.